### PR TITLE
add support for .mcmeta files

### DIFF
--- a/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/McMetaDeserializer.kt
+++ b/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/McMetaDeserializer.kt
@@ -1,0 +1,39 @@
+package be.mrtibo.ridecounters.displays.texture
+
+import com.google.gson.Gson
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import java.io.File
+import java.lang.reflect.Type
+
+object McMetaDeserializer : JsonDeserializer<Texture> {
+
+    private val gson = Gson().newBuilder()
+        .registerTypeAdapter(Texture::class.java, this)
+        .registerTypeAdapter(NineSliceBorder::class.java, NineSliceBorderDeserializer)
+        .create()
+
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type,
+        context: JsonDeserializationContext
+    ): Texture? {
+        if (!json.isJsonObject) throw JsonParseException("Could not deserialize texture")
+        val scaling = json.asJsonObject.getAsJsonObject("gui").getAsJsonObject("scaling")
+
+        return context.deserialize(scaling, when (val type = scaling.get("type").asString) {
+            "stretch" -> StretchTexture::class
+            "tile" -> TileTexture::class
+            "nine_slice" -> NineSliceTexture::class
+            else -> throw JsonParseException("Unknown scaling type '$type'.")
+        }.java)
+    }
+
+    fun deserialize(file: File): Texture {
+        val reader = file.bufferedReader()
+        return gson.fromJson(reader, Texture::class.java).also { reader.close() }
+    }
+
+}

--- a/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/NineSliceBorderDeserializer.kt
+++ b/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/NineSliceBorderDeserializer.kt
@@ -1,0 +1,22 @@
+package be.mrtibo.ridecounters.displays.texture
+
+import com.google.gson.Gson
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import java.lang.reflect.Type
+
+object NineSliceBorderDeserializer : JsonDeserializer<NineSliceBorder> {
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type,
+        context: JsonDeserializationContext
+    ): NineSliceBorder? {
+        return if (json.isJsonObject) {
+            Gson().fromJson(json, NineSliceBorder::class.java)
+        } else if (json.isJsonPrimitive) {
+            val border = json.asJsonPrimitive.asInt
+            NineSliceBorder(border, border, border, border)
+        } else null
+    }
+}

--- a/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/NineSliceBorderDeserializer.kt
+++ b/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/NineSliceBorderDeserializer.kt
@@ -7,6 +7,7 @@ import com.google.gson.JsonElement
 import java.lang.reflect.Type
 
 object NineSliceBorderDeserializer : JsonDeserializer<NineSliceBorder> {
+
     override fun deserialize(
         json: JsonElement,
         typeOfT: Type,
@@ -19,4 +20,5 @@ object NineSliceBorderDeserializer : JsonDeserializer<NineSliceBorder> {
             NineSliceBorder(border, border, border, border)
         } else null
     }
+
 }

--- a/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/NineSliceTexture.kt
+++ b/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/NineSliceTexture.kt
@@ -12,6 +12,7 @@ data class NineSliceTexture(
     val shouldStretch: Boolean = false,
     val border: NineSliceBorder
 ) : Texture {
+
     override fun applyMap(texture: MapTexture, canvas: MapCanvas) {
         val texture = MapTexture.resize(texture, width, height)
 
@@ -70,6 +71,7 @@ data class NineSliceTexture(
             }
         }
     }
+
 }
 
 data class NineSliceBorder(

--- a/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/NineSliceTexture.kt
+++ b/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/NineSliceTexture.kt
@@ -1,0 +1,80 @@
+package be.mrtibo.ridecounters.displays.texture
+
+import com.bergerkiller.bukkit.common.map.MapCanvas
+import com.bergerkiller.bukkit.common.map.MapTexture
+import com.google.common.primitives.Ints.min
+import com.google.gson.annotations.SerializedName
+
+data class NineSliceTexture(
+    val width: Int,
+    val height: Int,
+    @SerializedName("stretch_inner")
+    val shouldStretch: Boolean = false,
+    val border: NineSliceBorder
+) : Texture {
+    override fun applyMap(texture: MapTexture, canvas: MapCanvas) {
+        val texture = MapTexture.resize(texture, width, height)
+
+        // Corners
+        val topLeft = texture.getView(0, 0, border.left, border.top)
+        val topRight = texture.getView(width-border.right, 0, border.right, border.top)
+        val bottomLeft = texture.getView(0, height-border.bottom, border.left, border.bottom)
+        val bottomRight = texture.getView(width-border.right, height-border.bottom, border.left, border.bottom)
+
+        canvas.draw(topLeft, 0, 0)
+        canvas.draw(topRight, canvas.width-border.right, 0)
+        canvas.draw(bottomLeft, 0, canvas.height-border.bottom)
+        canvas.draw(bottomRight, canvas.width-border.right, canvas.height-border.bottom)
+
+        // Sides
+        val top = texture.getView(border.left, 0, width-border.left-border.right, border.top)
+        val bottom = texture.getView(border.left, height-border.bottom, width-border.left-border.right, border.bottom)
+        val left = texture.getView(0, border.top, border.left, height-border.top-border.bottom)
+        val right = texture.getView(width-border.right, border.top, border.right, height-border.top-border.bottom)
+
+        if (shouldStretch) {
+            canvas.draw(MapTexture.resize(top, canvas.width-border.left-border.right, border.top), border.left, 0)
+            canvas.draw(MapTexture.resize(bottom, canvas.width-border.left-border.right, border.bottom), border.left, canvas.height-border.bottom)
+            canvas.draw(MapTexture.resize(left, border.left, canvas.height-border.top-border.bottom), 0, border.top)
+            canvas.draw(MapTexture.resize(right, border.right, canvas.height-border.top-border.bottom), canvas.width-border.right, border.top)
+        } else {
+            for (x in 0 .. (canvas.width-border.left-border.right)/(width-border.left-border.right)) {
+                val xCoord = border.left+x*(width-border.left-border.right)
+                val size = min(xCoord+width, canvas.width-border.right)-xCoord
+                canvas.draw(top.getView(0, 0, size, top.height), xCoord, 0)
+                canvas.draw(bottom.getView(0, 0, size, bottom.height), xCoord, canvas.height-border.bottom)
+            }
+
+            for (y in 0 .. (canvas.height-border.top-border.bottom)/(height-border.top-border.bottom)) {
+                val yCoord = border.top+y*(height-border.top-border.bottom)
+                val size = min(yCoord+height, canvas.height-border.bottom)-yCoord
+                canvas.draw(left.getView(0, 0, left.width, size), 0, yCoord)
+                canvas.draw(right.getView(0, 0, right.width, size), canvas.width-border.right, yCoord)
+            }
+        }
+
+        // Inner
+        val inner = texture.getView(border.left, border.top, width-border.left-border.right, height-border.top-border.bottom)
+
+        if (shouldStretch) {
+            canvas.draw(MapTexture.resize(inner, canvas.width-border.left-border.right, canvas.height-border.top-border.bottom), border.left, border.top)
+        } else {
+            for (x in 0 .. (canvas.width-border.left-border.right)/inner.width) {
+                for (y in 0 .. (canvas.height-border.top-border.bottom)/inner.height) {
+                    val xCoord = border.left+x*inner.width
+                    val yCoord = border.top+y*inner.height
+                    val w = min(xCoord+inner.width, canvas.width-border.right)-xCoord
+                    val h = min(yCoord+inner.height, canvas.height-border.bottom)-yCoord
+                    canvas.draw(inner.getView(0, 0, w, h), xCoord, yCoord)
+                }
+            }
+        }
+    }
+}
+
+data class NineSliceBorder(
+    val left: Int,
+    val top: Int,
+    val right: Int,
+    val bottom: Int
+)

--- a/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/StretchTexture.kt
+++ b/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/StretchTexture.kt
@@ -1,0 +1,10 @@
+package be.mrtibo.ridecounters.displays.texture
+
+import com.bergerkiller.bukkit.common.map.MapCanvas
+import com.bergerkiller.bukkit.common.map.MapTexture
+
+class StretchTexture : Texture {
+    override fun applyMap(texture: MapTexture, canvas: MapCanvas) {
+        canvas.draw(MapTexture.resize(texture, canvas.width, canvas.height), 0, 0)
+    }
+}

--- a/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/StretchTexture.kt
+++ b/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/StretchTexture.kt
@@ -4,7 +4,9 @@ import com.bergerkiller.bukkit.common.map.MapCanvas
 import com.bergerkiller.bukkit.common.map.MapTexture
 
 class StretchTexture : Texture {
+
     override fun applyMap(texture: MapTexture, canvas: MapCanvas) {
         canvas.draw(MapTexture.resize(texture, canvas.width, canvas.height), 0, 0)
     }
+
 }

--- a/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/Texture.kt
+++ b/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/Texture.kt
@@ -1,0 +1,8 @@
+package be.mrtibo.ridecounters.displays.texture
+
+import com.bergerkiller.bukkit.common.map.MapCanvas
+import com.bergerkiller.bukkit.common.map.MapTexture
+
+interface Texture {
+    fun applyMap(texture: MapTexture, canvas: MapCanvas)
+}

--- a/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/Texture.kt
+++ b/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/Texture.kt
@@ -4,5 +4,7 @@ import com.bergerkiller.bukkit.common.map.MapCanvas
 import com.bergerkiller.bukkit.common.map.MapTexture
 
 interface Texture {
+
     fun applyMap(texture: MapTexture, canvas: MapCanvas)
+
 }

--- a/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/TileTexture.kt
+++ b/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/TileTexture.kt
@@ -1,0 +1,18 @@
+package be.mrtibo.ridecounters.displays.texture
+
+import com.bergerkiller.bukkit.common.map.MapCanvas
+import com.bergerkiller.bukkit.common.map.MapTexture
+
+data class TileTexture(
+    val width: Int,
+    val height: Int
+) : Texture {
+    override fun applyMap(texture: MapTexture, canvas: MapCanvas) {
+        val img = MapTexture.resize(texture, width, height)
+        for (x in 0 .. canvas.width/width) {
+            for (y in 0 .. canvas.height/height) {
+                canvas.draw(img, x*width, y*height)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/TileTexture.kt
+++ b/src/main/kotlin/be/mrtibo/ridecounters/displays/texture/TileTexture.kt
@@ -7,6 +7,7 @@ data class TileTexture(
     val width: Int,
     val height: Int
 ) : Texture {
+
     override fun applyMap(texture: MapTexture, canvas: MapCanvas) {
         val img = MapTexture.resize(texture, width, height)
         for (x in 0 .. canvas.width/width) {
@@ -15,4 +16,5 @@ data class TileTexture(
             }
         }
     }
+
 }


### PR DESCRIPTION
Add the ability to modify the appearance of custom image files using the .mcmeta format described [here](https://minecraft.wiki/w/Resource_pack#GUI)

The code has been tested. Without a .mcmeta file the image will fall back to previous stretching behaviour.

Images:
<img width="500" alt="test1" src="https://github.com/user-attachments/assets/33d9c949-212b-4777-97d6-01d8a78ae144" />
<img width="500" alt="test2" src="https://github.com/user-attachments/assets/8ee65dfa-6683-46d0-a118-42bd11ffbc2d" />
<img width="500" alt="button" src="https://github.com/user-attachments/assets/af2347b9-3d53-4e18-85a1-fb25bfd64087" />
